### PR TITLE
:sparkles: feat: ContentContainer, ContentItem base 컴포넌트 작성

### DIFF
--- a/src/components/base/ContentContainer/index.jsx
+++ b/src/components/base/ContentContainer/index.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { BORDER_STYLE } from '@utils/constants';
+
+const ContentContainer = ({ title, required, children }) => {
+  return (
+    <Container>
+      <ContentTitle>
+        <h2>{`${title}${required ? '*' : ''}`}</h2>
+      </ContentTitle>
+      {children}
+    </Container>
+  );
+}
+
+ContentContainer.propTypes = {
+  title: PropTypes.string,
+  required: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+ContentContainer.defaultProps = {
+  required: false,
+};
+
+const Container = styled.article`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  padding: 0;
+
+  border: ${BORDER_STYLE};
+`;
+
+const ContentTitle = styled.div`
+  padding: 1em 0.75em;
+  font-weight: bold;
+  border-bottom: ${BORDER_STYLE};
+`;
+
+export default ContentContainer;

--- a/src/components/base/ContentItem/index.jsx
+++ b/src/components/base/ContentItem/index.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { COLORS, BORDER_STYLE } from '@utils/constants';
+
+const ContentItem = ({ title, required, children }) => {
+  return (
+    <Container>
+      <Title>
+        <h3>{`${title}${required ? ' *' : ''}`}</h3>
+      </Title>
+      <Content>{children}</Content>
+    </Container>
+  );
+};
+
+ContentItem.propTypes = {
+  title: PropTypes.string,
+  required: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+ContentItem.defaultProps = {
+  required: false,
+};
+
+const Container = styled.section`
+  display: flex;
+  justify-content: flex-start;
+  align-items: stretch;
+  padding: 0;
+  border-bottom: ${BORDER_STYLE};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const Title = styled.div`
+  padding: 1em 0.75em;
+  width: 8.5em;
+  background-color: ${COLORS.grey_30};
+  border-right: ${BORDER_STYLE};
+`;
+
+const Content = styled.div`
+  width: calc(100% - 8.5em);
+`;
+
+export default ContentItem;

--- a/src/components/base/index.js
+++ b/src/components/base/index.js
@@ -1,1 +1,3 @@
 export { default as Icon } from './Icon';
+export { default as ContentContainer } from './ContentContainer';
+export { default as ContentItem } from './ContentItem';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,6 +7,8 @@ export const COLORS = {
   grey_60: '#e3e3e3', // 짙은 회색 배경 (상품 옵션)
   grey_30: '#fbfbfb', // 옅은 배경 회색
   grey_10: '#efefef', // 매우 옅은 회색 (이미지 첨부 배경)
-  border: '#f7f6f7', // border 컬러
+  border: '#e3e3e3', // border 컬러
   red: '#cd4950', // 삭제버튼
 };
+
+export const BORDER_STYLE = `2px solid ${COLORS.border}`;


### PR DESCRIPTION
## 세부 사항
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- ContentContainer, ContentItem base 컴포넌트를 작성했습니다.
  ContentContainer의 children으로 ContentItem을 사용하시면 됩니다.
- 두 컴포넌트 모두 required props를 가지고 있는데, `*`이 붙은 표 제목과 행 제목이 있는 것을 보고 넣었습니다.
- ContentItem의 children 부분은 기획서의 padding이 행마다 제각각이라 일부러 넣지 않았습니다. children을 Wrapper로 감싸고 필요한 만큼 padding을 넣는 식으로 사용하시면 될 것 같습니다.

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- COLORS contant의 border color를 e3e3e3으로 변경했습니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.

close #5
close #6