### PR TITLE
:recycle: refactor: Button 컴포넌트 리팩토링

### DIFF
--- a/src/components/base/Button/index.jsx
+++ b/src/components/base/Button/index.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-
 import { COLORS } from '@utils/constants';
 import buttonStyle from '@styles/buttonStyle';
+import { Icon } from '@components/base';
 
-const Button = ({ children, plusIcon, deleteIcon, ...props }) => {
+const Button = ({ children, plusIcon, deleteIcon, width, ...props }) => {
   return (
-    <CustomBtn {...props}>
-      <ImagePlus>{`${plusIcon ? '+' : ''}`}</ImagePlus>
-      <span>{children}</span>
-      <CategoryDel>{`${deleteIcon ? 'X' : ''}`}</CategoryDel>
+    <CustomBtn width={width} {...props}>
+      {plusIcon && <Icon name="ant-design:plus-outlined" height="0.8rem" />}
+      {children}
+      {deleteIcon && <Icon name="bi:x" height="1rem" />}
     </CustomBtn>
   );
 };
@@ -19,6 +19,7 @@ Button.propTypes = {
   children: PropTypes.node.isRequired,
   plusIcon: PropTypes.bool,
   deleteIcon: PropTypes.bool,
+  width: PropTypes.string,
 };
 
 Button.defaultProps = {
@@ -27,22 +28,16 @@ Button.defaultProps = {
 };
 
 const CustomBtn = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border: 1px solid ${COLORS.purple_90};
   border-radius: 5px;
-  padding: 0.2rem 0.6rem;
+  width: ${({ width }) => width || ''};
+  padding: 0.5rem 1rem;
   font-size: 1rem;
   background-color: #fff;
   ${buttonStyle}
-`;
-
-const ImagePlus = styled.span`
-  padding-right: 3px;
-`;
-
-const CategoryDel = styled.span`
-  padding-left: 8px;
-  font-size: 0.5rem;
-  font-weight: 600;
 `;
 
 export default Button;

--- a/src/components/base/index.js
+++ b/src/components/base/index.js
@@ -1,4 +1,5 @@
 export { default as Icon } from './Icon';
 export { default as Toggle } from './Toggle';
+export { default as Button } from './Button';
 export { default as ContentContainer } from './ContentContainer';
 export { default as ContentItem } from './ContentItem';


### PR DESCRIPTION
## 세부 사항
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- +, x를 Icon 컴포넌트로 대체
- 누락되었던 re-export 추가
- 불필요한 padding을 조건부 렌더링을 통해 삭제
- Button 자체의 padding 조정
- width props 추가

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- 이제 일정한 크기의 button이 필요한 경우 width를 지정해주시면 됩니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.

resolves #15