### PR TITLE
✨ feat: ImageUploadContainer 컴포넌트 구현

### DIFF
--- a/src/components/base/Upload/index.jsx
+++ b/src/components/base/Upload/index.jsx
@@ -47,7 +47,7 @@ Upload.propTypes = {
 
 Upload.defaultProps = {
   name: 'upload',
-  multiple: true,
+  multiple: false,
   onChange: () => {},
 };
 

--- a/src/components/base/Upload/index.jsx
+++ b/src/components/base/Upload/index.jsx
@@ -1,7 +1,8 @@
+import PropTypes from 'prop-types';
 import React, { useRef } from 'react';
 import styled from 'styled-components';
 
-const Upload = ({ children, onChange, name, ...props }) => {
+const Upload = ({ children, name, multiple, onChange, ...props }) => {
   const uploadInputRef = useRef(null);
 
   const handleUploadImage = () => {
@@ -14,6 +15,7 @@ const Upload = ({ children, onChange, name, ...props }) => {
         type="file"
         name={name}
         accept="image/jpg, image/jpeg, image/png"
+        multiple={multiple}
         ref={uploadInputRef}
         onChange={onChange}
       />
@@ -35,5 +37,18 @@ const Input = styled.input`
 const Button = styled.button`
   all: unset;
 `;
+
+Upload.propTypes = {
+  children: PropTypes.node.isRequired,
+  name: PropTypes.string,
+  multiple: PropTypes.bool,
+  onChange: PropTypes.func,
+};
+
+Upload.defaultProps = {
+  name: 'upload',
+  multiple: true,
+  onChange: () => {},
+};
 
 export default Upload;

--- a/src/components/domain/ImageUploadContainer/index.jsx
+++ b/src/components/domain/ImageUploadContainer/index.jsx
@@ -66,7 +66,6 @@ ImageUploadContainer.defaultProps = {
 
 const Container = styled.div`
   display: flex;
-  border: 1px solid ${COLORS.border};
   padding: 12px;
   gap: 24px;
   height: auto;

--- a/src/components/domain/ImageUploadContainer/index.jsx
+++ b/src/components/domain/ImageUploadContainer/index.jsx
@@ -1,0 +1,91 @@
+import styled from 'styled-components';
+import { COLORS } from '@utils/constants';
+import { Button, Upload, Icon } from '@components/base';
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import { v4 } from 'uuid';
+
+const ImageUploadContainer = ({ multiple }) => {
+  const [images, setImages] = useState([]);
+
+  console.log(images);
+  const handleUpload = (e) => {
+    const imagelist = [...e.target.files];
+    imagelist.map((image) => {
+      return setImages((images) =>
+        multiple
+          ? [
+              ...images,
+              {
+                id: v4(),
+                content: image.name,
+              },
+            ]
+          : [
+              {
+                id: v4(),
+                content: image.name,
+              },
+            ],
+      );
+    });
+  };
+
+  const handleDeleteClick = (id) => {
+    setImages(images.filter((item) => id !== item.id));
+  };
+
+  const handleFileName = (list) =>
+    list.map(({ id, content }, index) => (
+      <FileNameContainer key={index} id={id}>
+        {content}
+        <Button circleGrey onClick={() => handleDeleteClick(id)}>
+          <Icon name="cil:x" />
+        </Button>
+      </FileNameContainer>
+    ));
+
+  return (
+    <Container>
+      <Upload onChange={handleUpload} name="imageUpload" multiple={multiple}>
+        <Button width="164px" plusIcon>
+          이미지 첨부
+        </Button>
+      </Upload>
+      <FileNameListContainer>{handleFileName(images)}</FileNameListContainer>
+    </Container>
+  );
+};
+
+ImageUploadContainer.propTypes = {
+  multiple: PropTypes.bool,
+};
+
+ImageUploadContainer.defaultProps = {
+  multiple: false,
+};
+
+const Container = styled.div`
+  display: flex;
+  border: 1px solid ${COLORS.border};
+  padding: 12px;
+  gap: 24px;
+  height: auto;
+  box-sizing: border-box;
+`;
+
+const FileNameListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 5px;
+`;
+
+const FileNameContainer = styled.div`
+  display: flex;
+  position: relative;
+  align-items: center;
+  gap: 8px;
+`;
+
+export default ImageUploadContainer;

--- a/src/components/domain/ImageUploadContainer/index.jsx
+++ b/src/components/domain/ImageUploadContainer/index.jsx
@@ -8,7 +8,6 @@ import { v4 } from 'uuid';
 const ImageUploadContainer = ({ multiple }) => {
   const [images, setImages] = useState([]);
 
-  console.log(images);
   const handleUpload = (e) => {
     const imagelist = [...e.target.files];
     imagelist.map((image) => {

--- a/src/components/domain/index.js
+++ b/src/components/domain/index.js
@@ -1,0 +1,1 @@
+export { default as ImageUploadContainer } from './ImageUploadContainer';

--- a/src/styles/buttonStyle.jsx
+++ b/src/styles/buttonStyle.jsx
@@ -46,6 +46,16 @@ const buttonStyle = css`
       padding: 0.1rem 0.4rem;
       background-color: ${COLORS.yellowgreen};
     `}
+
+    ${(props) =>
+    props.circleGrey &&
+    css`
+      border: 1px solid ${COLORS.grey};
+      padding: 0;
+      width: 23px;
+      height: 23px;
+      border-radius: 50%;
+    `}
 `;
 
 export default buttonStyle;


### PR DESCRIPTION
## 세부 사항
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- ImageUploadContainer 컴포넌트 구현
- multiple prop 의 유무에 따라 단일 파일 업로드 / 다중 파일 업로드가 나뉩니다.
- 받아온 파일은 파일 이름만 필요하기 때문에 url 변경작업 등을 거치지 않고 이름만 뽑았습니다.
- uuid를 통해 업로드한 파일 하나하나에 고유 id를 부여하고, 삭제버튼을 아이디를 통한 filter로 구현하였습니다.
- 다중 파일 업로드를 위해 Upload base 컴포넌트를 수정했습니다.
  - prop으로 multiple 을 넘겨주면 다중 파일 선택이 가능합니다. 

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- 삭제 버튼 사용을 위해 Button 스타일을 추가했습니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
