### PR TITLE
:recycle: refactor: Icon 컴포넌트 height propTypes 변경

### DIFF
--- a/src/components/base/Icon/index.jsx
+++ b/src/components/base/Icon/index.jsx
@@ -8,7 +8,7 @@ const IconComponent = ({ name, color, height, ...props }) => {
 IconComponent.propTypes = {
   name: PropTypes.string,
   color: PropTypes.string,
-  height: PropTypes.number,
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 IconComponent.defaultProps = {


### PR DESCRIPTION
## 세부 사항
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- height에 string, number를 [둘 다 사용할 수 있는데](https://docs.iconify.design/icon-components/react/) propTypes에 number만 허용되어 있어 콘솔에 오류가 발생했습니다. oneOfType을 이용해 수정했습니다.

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- propTypes가 콘솔에 오류를 잘 띄워줘서 좋네요... ㅎㅎ
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.

close #25